### PR TITLE
webos: add github ci workflow and manifest building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build & Test
+
+on:
+  push:
+    branches: [ master, ci ]
+  pull_request:
+    branches: [ master, ci ]
+
+jobs:
+  webos-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./webos
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - run: npm ci
+    - run: npm run build-p
+    - run: npm run package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build & Release
+
+on:
+  push:
+    branches:
+      - '!*'
+    tags:
+      - 'v*.*'
+
+jobs:
+  webos-build-and-release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./webos
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - run: npm ci
+    - run: npm run build-p
+    - run: npm run package
+    - run: echo RELEASE_FILENAME_IPK=`ls *.ipk` >> $GITHUB_ENV
+    - run: npm run manifest
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+    - name: Upload IPK asset
+      id: upload-ipk-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ${{github.workspace}}/webos/${{env.RELEASE_FILENAME_IPK}}
+        asset_name: ${{env.RELEASE_FILENAME_IPK}}
+        asset_content_type: application/vnd.debian.binary-package
+
+    - name: Upload Manifest asset
+      id: upload-manifest-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ${{github.workspace}}/webos/me.wouterdek.magic4pc.manifest.json
+        asset_name: me.wouterdek.magic4pc.manifest.json
+        asset_content_type: application/json

--- a/webos/.editorconfig
+++ b/webos/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+
+[package.json]
+indent_style = space
+indent_size = 4

--- a/webos/.gitignore
+++ b/webos/.gitignore
@@ -13,3 +13,7 @@ dist
 # misc
 .DS_Store
 npm-debug.log
+
+.eslintcache
+*.ipk
+*.manifest.json

--- a/webos/package.json
+++ b/webos/package.json
@@ -15,7 +15,8 @@
     "test": "node ./scripts/test.js",
     "package": "ares-package -n dist/ service/",
     "test-watch": "node ./scripts/test.js --watch",
-    "manifest": "node ./scripts/gen-manifest.js me.wouterdek.magic4pc.manifest.json"
+    "manifest": "node ./scripts/gen-manifest.js me.wouterdek.magic4pc.manifest.json",
+    "version": "node ./scripts/sync-version.js && git add webos-meta/appinfo.json"
   },
   "license": "MIT",
   "private": true,

--- a/webos/package.json
+++ b/webos/package.json
@@ -14,7 +14,8 @@
     "license": "node ./scripts/license.js",
     "test": "node ./scripts/test.js",
     "package": "ares-package -n dist/ service/",
-    "test-watch": "node ./scripts/test.js --watch"
+    "test-watch": "node ./scripts/test.js --watch",
+    "manifest": "node ./scripts/gen-manifest.js me.wouterdek.magic4pc.manifest.json"
   },
   "license": "MIT",
   "private": true,

--- a/webos/scripts/gen-manifest.js
+++ b/webos/scripts/gen-manifest.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+const crypto = require('crypto');
+const fs = require('fs');
+
+const outfile = process.argv[2];
+const appinfo = JSON.parse(fs.readFileSync('webos-meta/appinfo.json'));
+const ipkfile = `${appinfo.id}_${appinfo.version}_all.ipk`;
+const ipkhash = crypto.createHash('sha256').update(fs.readFileSync(ipkfile)).digest('hex');
+
+fs.writeFileSync(
+  outfile,
+  JSON.stringify({
+    id: appinfo.id,
+    version: appinfo.version,
+    type: appinfo.type,
+    title: appinfo.title,
+    appDescription: appinfo.appDescription,
+    iconUri: 'https://raw.githubusercontent.com/Wouterdek/magic4pc/master/webos/webos-meta/icon-large.png',
+    sourceUrl: 'https://github.com/Wouterdek/magic4pc',
+    rootRequired: false,
+    ipkUrl: ipkfile,
+    ipkHash: {
+      sha256: ipkhash,
+    },
+  }),
+);

--- a/webos/scripts/sync-version.js
+++ b/webos/scripts/sync-version.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const packageInfo = JSON.parse(fs.readFileSync('package.json'));
+const appInfo = JSON.parse(fs.readFileSync('webos-meta/appinfo.json'));
+
+fs.writeFileSync(
+	'webos-meta/appinfo.json',
+	`${JSON.stringify(
+		{
+			...appInfo,
+			version: packageInfo.version,
+		},
+		null,
+		'\t',
+	)}\n`,
+);

--- a/webos/src/views/MainPanel.js
+++ b/webos/src/views/MainPanel.js
@@ -1,9 +1,9 @@
+/* eslint-disable no-unused-vars */
+
 import Button from '@enact/sandstone/Button';
-import {Dropdown, DropdownDecorator} from '@enact/sandstone/Dropdown';
+import {Dropdown} from '@enact/sandstone/Dropdown';
 import {SwitchItem} from '@enact/sandstone/SwitchItem';
 import Popup from '@enact/sandstone/Popup';
-import kind from '@enact/core/kind';
-import {Panel, Header} from '@enact/sandstone/Panels';
 import LS2Request from '@enact/webos/LS2Request';
 import React from 'react'
 
@@ -162,7 +162,7 @@ class MainPanel extends React.Component {
 
 	onCursorVisibilityChange(e)
 	{
-		var isVisible = e.detail.visibility;
+		let isVisible = e.detail.visibility;
 		this.setState({settingsButtonVisible: isVisible});
 	}
 
@@ -240,7 +240,7 @@ class MainPanel extends React.Component {
 		'AV 1',
 		'AV 2',
 	]
-	
+
 	inputSources = [
 		'ext://hdmi:1',
 		'ext://hdmi:2',
@@ -305,7 +305,7 @@ class MainPanel extends React.Component {
 		bottom: 0,
 		zIndex: 2
 	}
-	
+
 	handleOpenPopup()
 	{
 		this.setState({popupOpen: true});

--- a/webos/webos-meta/appinfo.json
+++ b/webos/webos-meta/appinfo.json
@@ -13,5 +13,7 @@
 	"uiRevision": 2,
 	"disableBackHistoryAPI": true,
 	"supportGIP": true,
-	"requiredPermissions": [""]
+	"requiredPermissions": [
+		""
+	]
 }

--- a/webos/webos-meta/appinfo.json
+++ b/webos/webos-meta/appinfo.json
@@ -1,5 +1,6 @@
 {
 	"id": "me.wouterdek.magic4pc",
+	"appDescription": "Use MagicRemote as an input device on a PC",
 	"version": "1.0.0",
 	"vendor": "WouterDeK",
 	"type": "web",


### PR DESCRIPTION
~~**Note:** this will *probably* not work correctly, since I am unable to test this in my fork for some reason, probably because a run needs to be approved by upstream repository owner.~~ Disregard that, I am stupid.

This adds GitHub CI workflows that'll:

* `main`: just build and package an app on every commit
* `release`: build and package an app, generate a webosbrew manifest and create a GitHub Release "prerelease", when a `vX.X` tag is created.

webosbrew package manifest will allow for publishing on https://repo.webosbrew.org

This has been confirmed to work as intended, though will benefit from a minor cleanup I'll add in the following days.