### PR TITLE
webos: Add support for mouse click and wheel

### DIFF
--- a/webos/service/m4p_service.js
+++ b/webos/service/m4p_service.js
@@ -162,18 +162,36 @@ function startUnicastingData(client, rinfo, request) {
 	setupSensorSubscription();
 }
 
-function onInput(parameters) {
-	var msg = JSON.stringify({
-		t: 'input',
-		parameters: parameters,
-	});
+function sendToClient(msg) {
+	const data = JSON.stringify(msg);
 	unicastClient.send(
-		msg,
+		data,
 		0,
-		msg.length,
+		data.length,
 		unicastRInfo.port,
 		unicastRInfo.address
 	);
+}
+
+function onInput(parameters) {
+	sendToClient({
+		t: 'input',
+		parameters: parameters,
+	});
+}
+
+function onMouse(parameters) {
+	sendToClient({
+		t: 'mouse',
+		mouse: parameters,
+	});
+}
+
+function onWheel(parameters) {
+	sendToClient({
+		t: 'wheel',
+		wheel: parameters,
+	});
 }
 
 function buildUpdatePayload(data, settings) {
@@ -331,6 +349,24 @@ service.register('start', function (message) {
 service.register('onInput', function (message) {
 	if (unicastDataActive) {
 		onInput(message.payload);
+	}
+	message.respond({
+		//TODO
+	});
+});
+
+service.register('onMouse', function (message) {
+	if (unicastDataActive) {
+		onMouse(message.payload);
+	}
+	message.respond({
+		//TODO
+	});
+});
+
+service.register('onWheel', function (message) {
+	if (unicastDataActive) {
+		onWheel(message.payload);
 	}
 	message.respond({
 		//TODO

--- a/webos/src/views/MainPanel.js
+++ b/webos/src/views/MainPanel.js
@@ -153,6 +153,34 @@ class MainPanel extends React.Component {
 		this.setState({settingsButtonVisible: isVisible});
 	}
 
+	onMouse(e) {
+		console.log(e.type);
+
+		new LS2Request().send({
+			service: 'luna://me.wouterdek.magic4pc.service/',
+			method: 'onMouse',
+			parameters: {
+				type: e.type, // mousedown, mouseup
+				x: e.screenX,
+				y: e.screenY,
+			},
+		});
+	}
+
+	onWheel(e) {
+		console.log('wheel', e.wheelDelta > 0 ? 'up' : 'down');
+
+		new LS2Request().send({
+			service: 'luna://me.wouterdek.magic4pc.service/',
+			method: 'onWheel',
+			parameters: {
+				x: e.screenX,
+				y: e.screenY,
+				delta: e.wheelDelta,
+			},
+		});
+	}
+
 	componentDidMount() {
 		document.addEventListener('keydown', this.onButtonDown, false);
 		document.addEventListener('keyup', this.onButtonUp, false);
@@ -166,6 +194,9 @@ class MainPanel extends React.Component {
 			this.onCursorVisibilityChange,
 			false
 		);
+		document.addEventListener('mousedown', this.onMouse, false);
+		document.addEventListener('mouseup', this.onMouse, false);
+		document.addEventListener('wheel', this.onWheel, false);
 		this.loadSettings();
 
 		new LS2Request().send({


### PR DESCRIPTION
This PR adds support for mouse clicking and scrolling via the magic remotes wheel.

Mouse click is supported via `mousedown` and `mouseup` events so that we can perform short and long presses. The `click` event would have been another approach, but considering down/up provides more metadata, it was omitted for now.

I had originally implemented support for `touchstart`, `touchmove` and `touchend` as well, however, in hindsight these do not provide much over the current mouse movements combined with `mousedown` and `mouseup`. Furthermore, enabling touch requires changes to the apps `package.json` and disables `mousedown` and `mouseup`, so it becomes something of an either-or approach. The `click` event can still happen with touch enabled, but it's easily canceled out by slight movement of the magic remote (in which case it becomes a series of `touchmove`'s instead).

For now, I have not touched the `pc` package although a reference client implementation exists in: https://github.com/mafredri/magic4linux/commit/2bf53f0397f16ee0367be99373b57dadf1742195

**NOTE:** This is currently based off the #9 PR, if you do not want it merged I'll rebase this on current master.

Related: #7

---

**Edit:** I forgot to mention that I've included coordinates in these payloads because there may be cases you want to ensure the mouse location isn't based on the separate hardware sensor stream and instead use the location where it was actually reported. Then again, since we're using `mousedown` and `mouseup`, we could also use `mousemove`, but I don't know if there would be a benefit to this as opposed to the sensor data.