### PR TITLE
Fix broken CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,11 @@
 name: Build & Test
 
 on:
-  push:
-    branches: [ master, ci ]
   pull_request:
-    branches: [ master, ci ]
+    branches: [ master ]
+  push:
+    paths:
+      - 'webos/**'
 
 jobs:
   webos-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,9 @@ jobs:
     - run: npm ci
     - run: npm run build-p
     - run: npm run package
+    - name: Archive built webOS app
+      uses: actions/upload-artifact@v3
+      with:
+        name: webos-app
+        path: |
+          webos/*.ipk

--- a/webos/package-lock.json
+++ b/webos/package-lock.json
@@ -19167,6 +19167,11 @@
 			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 			"dev": true
 		},
+		"ilib": {
+			"version": "npm:ilib-webos@14.6.2-webos1",
+			"resolved": "https://registry.npmjs.org/ilib-webos/-/ilib-webos-14.6.2-webos1.tgz",
+			"integrity": "sha512-ARxB3LdKZcZNJ394TRjSDOVnVTcoStLUamI0YNV8dHNWBIJzJxvzU79Ihf89eiq/z8uGhYvYqxUihF2NR80N9g=="
+		},
 		"image-size": {
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",


### PR DESCRIPTION
This fixes CI build by updating package-lock.json (one dependency accidentally removed when merging #10), makes CI run on all branches by default and adds publishing of built development webOS app ipk file in Artifacts tab of GitHub CI. (these are stored/downloadable up to 90 days by default)